### PR TITLE
Add cross-system coupon deactivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A comprehensive Next.js application for managing coupon codes with interactive s
 - **Multi-Panel System** - Admin, Store, Customer, and View interfaces
 - **Real-time Tracking** - Complete audit trail of coupon lifecycle
 - **Store Management** - 18 store locations with employee tracking
+- **Shopify Sync** - Codes stay in sync with Shopify for redemptions and manual deactivations
 
 ### 🎨 Modern UI/UX
 
@@ -142,6 +143,8 @@ CREATE TABLE coupons (
 - `POST /api/coupons/generate` - Generate new coupons
 - `POST /api/coupons/validate` - Validate coupon code
 - `POST /api/coupons/scratch` - Mark coupon as scratched
+- `POST /api/shopify/redeem` - Mark a coupon as used from Shopify checkout
+- `POST /api/shopify/deactivate` - Deactivate a local coupon when its Shopify discount is disabled
 
 ### Request/Response Examples
 

--- a/src/app/api/shopify/deactivate/route.js
+++ b/src/app/api/shopify/deactivate/route.js
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { getCouponByCode, initDatabase, deactivateCoupon } from '@/lib/database';
+
+export async function POST(request) {
+  try {
+    initDatabase();
+    const { code } = await request.json();
+
+    if (!code) {
+      return NextResponse.json({ success: false, message: 'Coupon code is required' }, { status: 400 });
+    }
+
+    const coupon = getCouponByCode(code);
+    if (!coupon) {
+      return NextResponse.json({ success: false, message: 'Coupon not found' }, { status: 404 });
+    }
+
+    const result = deactivateCoupon(code);
+    const updatedCoupon = getCouponByCode(code);
+    return NextResponse.json({ ...result, couponDetails: updatedCoupon });
+  } catch (error) {
+    console.error('Shopify deactivate API error:', error);
+    return NextResponse.json({ success: false, message: 'Error deactivating coupon', error: error.message }, { status: 500 });
+  }
+}
+

--- a/src/app/api/shopify/redeem/route.js
+++ b/src/app/api/shopify/redeem/route.js
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { validateCoupon, getCouponByCode, initDatabase } from '@/lib/database';
+import { deactivateShopifyDiscount } from '@/lib/shopify';
+
+export async function POST(request) {
+  try {
+    initDatabase();
+    const { code } = await request.json();
+
+    if (!code) {
+      return NextResponse.json({ success: false, message: 'Coupon code is required' }, { status: 400 });
+    }
+
+    const coupon = getCouponByCode(code);
+    if (!coupon) {
+      return NextResponse.json({ success: false, message: 'Coupon not found' }, { status: 404 });
+    }
+    if (coupon.status !== 'active') {
+      return NextResponse.json({ success: false, message: 'Coupon is not active', couponDetails: coupon }, { status: 400 });
+    }
+
+    const result = validateCoupon(code, 'SHOPIFY', 0);
+    if (result.success && coupon.shopify_discount_id) {
+      await deactivateShopifyDiscount(coupon.shopify_discount_id);
+    }
+
+    const updatedCoupon = getCouponByCode(code);
+    return NextResponse.json({ ...result, couponDetails: updatedCoupon });
+  } catch (error) {
+    console.error('Shopify redeem API error:', error);
+    return NextResponse.json({ success: false, message: 'Error deactivating coupon', error: error.message }, { status: 500 });
+  }
+}

--- a/src/lib/database.js
+++ b/src/lib/database.js
@@ -164,6 +164,22 @@ export function validateCoupon(code, employeeCode, storeLocation) {
   }
 }
 
+// Deactivate coupon without marking as used
+export function deactivateCoupon(code) {
+  const coupon = getCouponByCode(code);
+  if (!coupon) return { success: false, message: 'Coupon not found' };
+  if (coupon.status !== 'active') return { success: false, message: 'Coupon is not active' };
+
+  const updateStmt = db.prepare(`
+    UPDATE coupons
+    SET status = 'inactive'
+    WHERE code = ?
+  `);
+
+  updateStmt.run(code);
+  return { success: true, message: 'Coupon deactivated successfully' };
+}
+
 // Scratch coupon
 export function scratchCoupon(code) {
   const coupon = getCouponByCode(code);

--- a/src/lib/shopify.js
+++ b/src/lib/shopify.js
@@ -167,3 +167,59 @@ export async function createShopifyDiscount(couponCode) {
     };
   }
 }
+
+export async function getShopifyDiscountStatus(discountId) {
+  try {
+    if (!discountId) throw new Error('No discount ID provided');
+
+    const query = `
+      query discountCode($id: ID!) {
+        codeDiscountNode(id: $id) {
+          codeDiscount {
+            ... on DiscountCodeBasic {
+              status
+            }
+          }
+        }
+      }
+    `;
+
+    const response = await client.request(query, { variables: { id: discountId } });
+    const status = response.data?.codeDiscountNode?.codeDiscount?.status;
+    return { success: true, status };
+  } catch (error) {
+    console.error('❌ Shopify discount status fetch error:', error);
+    return { success: false, message: error.message };
+  }
+}
+
+export async function deactivateShopifyDiscount(discountId) {
+  try {
+    if (!discountId) {
+      throw new Error('No discount ID provided');
+    }
+
+    const mutation = `
+      mutation discountDeactivate($id: ID!) {
+        discountDeactivate(id: $id) {
+          codeDiscountNode { id }
+          userErrors { field message }
+        }
+      }
+    `;
+
+    const response = await client.request(mutation, {
+      variables: { id: discountId }
+    });
+
+    const errors = response.data?.discountDeactivate?.userErrors;
+    if (errors && errors.length > 0) {
+      throw new Error(errors.map(e => e.message).join(', '));
+    }
+
+    return { success: true };
+  } catch (error) {
+    console.error('❌ Shopify discount deactivation error:', error);
+    return { success: false, message: error.message };
+  }
+}


### PR DESCRIPTION
## Summary
- sync local coupons when Shopify discount codes are disabled
- expose API endpoint for Shopify-driven local deactivation
- document Shopify deactivation sync behavior and endpoint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc59c6796c832f990e8efae069f192